### PR TITLE
Changes to also compile on ARM architecture

### DIFF
--- a/var_make_debian.sh
+++ b/var_make_debian.sh
@@ -26,26 +26,22 @@ readonly DEF_SRC_DIR="${DEF_BUILDENV}/src"
 readonly G_ROOTFS_DIR="${DEF_BUILDENV}/rootfs"
 readonly G_TMP_DIR="${DEF_BUILDENV}/tmp"
 if [[ "$ARCHITECTURE" == "x86_64" ]]; then
-readonly G_TOOLS_PATH="${DEF_BUILDENV}/toolchain"
-else
-	echo "Delete reference to G_TOOLS_PATH"
+	readonly G_TOOLS_PATH="${DEF_BUILDENV}/toolchain"
 fi
 readonly G_VARISCITE_PATH="${DEF_BUILDENV}/variscite"
 
 if [[ "$ARCHITECTURE" == "x86_64" ]]; then
-#64 bit CROSS_COMPILER config and paths
-readonly G_CROSS_COMPILER_64BIT_NAME="gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu"
-readonly G_CROSS_COMPILER_ARCHIVE_64BIT="${G_CROSS_COMPILER_64BIT_NAME}.tar.xz"
-readonly G_EXT_CROSS_64BIT_COMPILER_LINK="http://releases.linaro.org/components/toolchain/binaries/6.3-2017.05/aarch64-linux-gnu/${G_CROSS_COMPILER_ARCHIVE_64BIT}"
-readonly G_CROSS_COMPILER_64BIT_PREFIX="aarch64-linux-gnu-"
+	#64 bit CROSS_COMPILER config and paths
+	readonly G_CROSS_COMPILER_64BIT_NAME="gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu"
+	readonly G_CROSS_COMPILER_ARCHIVE_64BIT="${G_CROSS_COMPILER_64BIT_NAME}.tar.xz"
+	readonly G_EXT_CROSS_64BIT_COMPILER_LINK="http://releases.linaro.org/components/toolchain/binaries/6.3-2017.05/aarch64-linux-gnu/${G_CROSS_COMPILER_ARCHIVE_64BIT}"
+	readonly G_CROSS_COMPILER_64BIT_PREFIX="aarch64-linux-gnu-"
 
-#32 bit CROSS_COMPILER config and paths
-readonly G_CROSS_COMPILER_32BIT_NAME="gcc-linaro-6.3.1-2017.05-x86_64_arm-linux-gnueabihf"
-readonly G_CROSS_COMPILER_ARCHIVE_32BIT="${G_CROSS_COMPILER_32BIT_NAME}.tar.xz"
-readonly G_EXT_CROSS_32BIT_COMPILER_LINK="http://releases.linaro.org/components/toolchain/binaries/6.3-2017.05/arm-linux-gnueabihf/${G_CROSS_COMPILER_ARCHIVE_32BIT}"
-readonly G_CROSS_COMPILER_32BIT_PREFIX="arm-linux-gnueabihf-"
-else
-	echo "Remove cross compiler related setting"
+	#32 bit CROSS_COMPILER config and paths
+	readonly G_CROSS_COMPILER_32BIT_NAME="gcc-linaro-6.3.1-2017.05-x86_64_arm-linux-gnueabihf"
+	readonly G_CROSS_COMPILER_ARCHIVE_32BIT="${G_CROSS_COMPILER_32BIT_NAME}.tar.xz"
+	readonly G_EXT_CROSS_32BIT_COMPILER_LINK="http://releases.linaro.org/components/toolchain/binaries/6.3-2017.05/arm-linux-gnueabihf/${G_CROSS_COMPILER_ARCHIVE_32BIT}"
+	readonly G_CROSS_COMPILER_32BIT_PREFIX="arm-linux-gnueabihf-"
 fi
 
 readonly G_CROSS_COMPILER_JOPTION="-j`nproc`"
@@ -110,13 +106,11 @@ if [ ! -z "${G_FREERTOS_VAR_SRC_DIR}" ]; then
 fi
 
 if [[ "$ARCHITECTURE" == "x86_64" ]]; then
-# Setup cross compiler path, name, kernel dtb path, kernel image type, helper scripts
-G_CROSS_COMPILER_NAME=${G_CROSS_COMPILER_64BIT_NAME}
-G_EXT_CROSS_COMPILER_LINK=${G_EXT_CROSS_64BIT_COMPILER_LINK}
-G_CROSS_COMPILER_ARCHIVE=${G_CROSS_COMPILER_ARCHIVE_64BIT}
-G_CROSS_COMPILER_PREFIX=${G_CROSS_COMPILER_64BIT_PREFIX}
-else
-	echo "Ignores configurations for _x64 architecture"
+	# Setup cross compiler path, name, kernel dtb path, kernel image type, helper scripts
+	G_CROSS_COMPILER_NAME=${G_CROSS_COMPILER_64BIT_NAME}
+	G_EXT_CROSS_COMPILER_LINK=${G_EXT_CROSS_64BIT_COMPILER_LINK}
+	G_CROSS_COMPILER_ARCHIVE=${G_CROSS_COMPILER_ARCHIVE_64BIT}
+	G_CROSS_COMPILER_PREFIX=${G_CROSS_COMPILER_64BIT_PREFIX}
 fi
 ARCH_ARGS="arm64"
 BUILD_IMAGE_TYPE="Image.gz"
@@ -318,25 +312,25 @@ function make_kernel()
 	pr_info "make kernel .config"
 
     if [[ "$ARCHITECTURE" == "x86_64" ]]; then
-	make ARCH=${ARCH_ARGS} CROSS_COMPILE=${1} ${G_CROSS_COMPILER_JOPTION} -C ${4}/ ${2}
-else
+		make ARCH=${ARCH_ARGS} CROSS_COMPILE=${1} ${G_CROSS_COMPILER_JOPTION} -C ${4}/ ${2}
+	else
         make ARCH=${ARCH_ARGS} ${G_CROSS_COMPILER_JOPTION} -C ${4}/ ${2}
     fi
 	pr_info "make kernel"
 	if [ ! -z "${UIMAGE_LOADADDR}" ]; then
 		IMAGE_EXTRA_ARGS="LOADADDR=${UIMAGE_LOADADDR}"
 	fi
-if [[ "$ARCHITECTURE" == "x86_64" ]]; then
-	make CROSS_COMPILE=${1} ARCH=${ARCH_ARGS} ${G_CROSS_COMPILER_JOPTION} ${IMAGE_EXTRA_ARGS}\
+	if [[ "$ARCHITECTURE" == "x86_64" ]]; then
+		make CROSS_COMPILE=${1} ARCH=${ARCH_ARGS} ${G_CROSS_COMPILER_JOPTION} ${IMAGE_EXTRA_ARGS}\
 			-C ${4}/ ${BUILD_IMAGE_TYPE}
-else
+	else
         make ARCH=${ARCH_ARGS} ${G_CROSS_COMPILER_JOPTION} ${IMAGE_EXTRA_ARGS}\
             -C ${4}/ ${BUILD_IMAGE_TYPE}
     fi    
 	pr_info "make ${3}"
-if [[ "$ARCHITECTURE" == "x86_64" ]]; then
-	make CROSS_COMPILE=${1} ARCH=${ARCH_ARGS} ${G_CROSS_COMPILER_JOPTION} -C ${4} ${3}
-else
+	if [[ "$ARCHITECTURE" == "x86_64" ]]; then
+		make CROSS_COMPILE=${1} ARCH=${ARCH_ARGS} ${G_CROSS_COMPILER_JOPTION} -C ${4} ${3}
+	else
         make ARCH=${ARCH_ARGS} ${G_CROSS_COMPILER_JOPTION} -C ${4} ${3}
     fi
 	pr_info "Copy kernel and dtb files to output dir: ${5}"
@@ -360,20 +354,20 @@ function clean_kernel()
 # $4 -- out modules path
 function make_kernel_modules()
 {
-if [[ "$ARCHITECTURE" == "x86_64" ]]; then
-	pr_info "make kernel defconfig"
-	make ARCH=${ARCH_ARGS} CROSS_COMPILE=${1} ${G_CROSS_COMPILER_JOPTION} -C ${3} ${2}
-else
+	if [[ "$ARCHITECTURE" == "x86_64" ]]; then
+		pr_info "make kernel defconfig"
+		make ARCH=${ARCH_ARGS} CROSS_COMPILE=${1} ${G_CROSS_COMPILER_JOPTION} -C ${3} ${2}
+	else
 		pr_info "make kernel defconfig for arm"
-    		make ARCH=${ARCH_ARGS} ${G_CROSS_COMPILER_JOPTION} -C ${3} ${2}
+    	make ARCH=${ARCH_ARGS} ${G_CROSS_COMPILER_JOPTION} -C ${3} ${2}
 	fi
 
-if [[ "$ARCHITECTURE" == "x86_64" ]]; then
-	pr_info "Compiling kernel modules"
-	make ARCH=${ARCH_ARGS} CROSS_COMPILE=${1} ${G_CROSS_COMPILER_JOPTION} -C ${3} modules
-else
+	if [[ "$ARCHITECTURE" == "x86_64" ]]; then
+		pr_info "Compiling kernel modules"
+		make ARCH=${ARCH_ARGS} CROSS_COMPILE=${1} ${G_CROSS_COMPILER_JOPTION} -C ${3} modules
+	else
 		pr_info "Compiling kernel modules for arm"
-        	make ARCH=${ARCH_ARGS} ${G_CROSS_COMPILER_JOPTION} -C ${3} modules
+        make ARCH=${ARCH_ARGS} ${G_CROSS_COMPILER_JOPTION} -C ${3} modules
 	fi
 }
 
@@ -390,13 +384,13 @@ function make_kernel_headers_package()
 	pr_info "Installing kernel modules to ${4}"
 
 	if [[ "$ARCHITECTURE" == "x86_64" ]]; then
-	make ARCH=${ARCH_ARGS} CROSS_COMPILE=${1} \
+		make ARCH=${ARCH_ARGS} CROSS_COMPILE=${1} \
 		${G_CROSS_COMPILER_JOPTION} -C ${3} \
 		INSTALL_MOD_PATH=${4} modules_install
-else
+	else
 		make ARCH=${ARCH_ARGS} \
-        		${G_CROSS_COMPILER_JOPTION} -C ${3} \
-        		INSTALL_MOD_PATH=${4} modules_install
+        ${G_CROSS_COMPILER_JOPTION} -C ${3} \
+        INSTALL_MOD_PATH=${4} modules_install
 	fi
 }
 # install the Linux kernel modules
@@ -406,24 +400,24 @@ else
 # $4 -- out modules path
 function install_kernel_modules()
 {
-if [[ "$ARCHITECTURE" == "x86_64" ]]; then
-	pr_info "Installing kernel headers to ${4}"
-	make ARCH=${ARCH_ARGS} CROSS_COMPILE=${1} ${G_CROSS_COMPILER_JOPTION} -C ${3} \
+	if [[ "$ARCHITECTURE" == "x86_64" ]]; then
+		pr_info "Installing kernel headers to ${4}"
+		make ARCH=${ARCH_ARGS} CROSS_COMPILE=${1} ${G_CROSS_COMPILER_JOPTION} -C ${3} \
 		INSTALL_HDR_PATH=${4}/usr/local headers_install
-else
+	else
 		pr_info "Installing kernel headers to ${4}"
 		make ARCH=${ARCH_ARGS} ${G_CROSS_COMPILER_JOPTION} -C ${3} \
-			INSTALL_HDR_PATH=${4}/usr/local headers_install
+		INSTALL_HDR_PATH=${4}/usr/local headers_install
 	fi
 
-if [[ "$ARCHITECTURE" == "x86_64" ]]; then
-	pr_info "Installing kernel modules to ${4}"
-	make ARCH=${ARCH_ARGS} CROSS_COMPILE=${1} ${G_CROSS_COMPILER_JOPTION} -C ${3} \
+	if [[ "$ARCHITECTURE" == "x86_64" ]]; then
+		pr_info "Installing kernel modules to ${4}"
+		make ARCH=${ARCH_ARGS} CROSS_COMPILE=${1} ${G_CROSS_COMPILER_JOPTION} -C ${3} \
 		INSTALL_MOD_PATH=${4} modules_install
-else
+	else
 		pr_info "Installing kernel modules to ${4}"
 		make ARCH=${ARCH_ARGS} ${G_CROSS_COMPILER_JOPTION} -C ${3} \
-			INSTALL_MOD_PATH=${4} modules_install
+		INSTALL_MOD_PATH=${4} modules_install
 	fi
 }
 
@@ -511,58 +505,58 @@ function make_uboot()
 {
 	pr_info "Make U-Boot: ${G_UBOOT_DEF_CONFIG_MMC}"
 
-if [[ "$ARCHITECTURE" == "x86_64" ]]; then
-	# clean work directory
-	make ARCH=${ARCH_ARGS} -C ${1} \
+	if [[ "$ARCHITECTURE" == "x86_64" ]]; then
+		# clean work directory
+		make ARCH=${ARCH_ARGS} -C ${1} \
 		CROSS_COMPILE=${G_CROSS_COMPILER_PATH}/${G_CROSS_COMPILER_PREFIX} \
 		${G_CROSS_COMPILER_JOPTION} mrproper
-else
+	else
 		make ARCH=${ARCH_ARGS} -C ${1} \
-			${G_CROSS_COMPILER_JOPTION} mrproper
+		${G_CROSS_COMPILER_JOPTION} mrproper
 	fi
 
-if [[ "$ARCHITECTURE" == "x86_64" ]]; then
-	# make U-Boot mmc defconfig
-	make ARCH=${ARCH_ARGS} -C ${1} \
+	if [[ "$ARCHITECTURE" == "x86_64" ]]; then
+		# make U-Boot mmc defconfig
+		make ARCH=${ARCH_ARGS} -C ${1} \
 		CROSS_COMPILE=${G_CROSS_COMPILER_PATH}/${G_CROSS_COMPILER_PREFIX} \
 		${G_CROSS_COMPILER_JOPTION} ${G_UBOOT_DEF_CONFIG_MMC}
-else
+	else
 		make ARCH=${ARCH_ARGS} -C ${1} \
-			${G_CROSS_COMPILER_JOPTION} ${G_UBOOT_DEF_CONFIG_MMC}
+		${G_CROSS_COMPILER_JOPTION} ${G_UBOOT_DEF_CONFIG_MMC}
 	fi
 
-if [[ "$ARCHITECTURE" == "x86_64" ]]; then
-	# make U-Boot
-	make -C ${1} \
-		CROSS_COMPILE=${G_CROSS_COMPILER_PATH}/${G_CROSS_COMPILER_PREFIX} \
-		${G_CROSS_COMPILER_JOPTION}
-else
+	if [[ "$ARCHITECTURE" == "x86_64" ]]; then
 		# make U-Boot
 		make -C ${1} \
-			${G_CROSS_COMPILER_JOPTION}
-	fi
-
-if [[ "$ARCHITECTURE" == "x86_64" ]]; then
-	# make fw_printenv
-	make envtools -C ${1} \
 		CROSS_COMPILE=${G_CROSS_COMPILER_PATH}/${G_CROSS_COMPILER_PREFIX} \
 		${G_CROSS_COMPILER_JOPTION}
-else
+	else
+		# make U-Boot
+		make -C ${1} \
+		${G_CROSS_COMPILER_JOPTION}
+	fi
+
+	if [[ "$ARCHITECTURE" == "x86_64" ]]; then
+		# make fw_printenv
 		make envtools -C ${1} \
-			${G_CROSS_COMPILER_JOPTION}
+		CROSS_COMPILE=${G_CROSS_COMPILER_PATH}/${G_CROSS_COMPILER_PREFIX} \
+		${G_CROSS_COMPILER_JOPTION}
+	else
+		make envtools -C ${1} \
+		${G_CROSS_COMPILER_JOPTION}
 	fi
 
 	cp ${1}/tools/env/fw_printenv ${2}
 
-if [[ "$ARCHITECTURE" == "x86_64" ]]; then
-	cd ${DEF_SRC_DIR}/imx-atf
-	LDFLAGS="" make CROSS_COMPILE=${G_CROSS_COMPILER_PATH}/${G_CROSS_COMPILER_PREFIX} \
-			PLAT=imx8mn bl31
-else
+	if [[ "$ARCHITECTURE" == "x86_64" ]]; then
+		cd ${DEF_SRC_DIR}/imx-atf
+		LDFLAGS="" make CROSS_COMPILE=${G_CROSS_COMPILER_PATH}/${G_CROSS_COMPILER_PREFIX} \
+		PLAT=imx8mn bl31
+	else
 		cd ${DEF_SRC_DIR}/imx-atf
 		cp Makefile Makefile.backup
 
-		# Modificar Makefile para incluir las opciones adicionales
+		# The Makefile is modified to include the following flags during compilation
 		sed -i 's|ERRORS := -Werror|ERRORS := -Werror -Wno-error=array-bounds|' Makefile
 		sed -i '/TF_LDFLAGS.*--gc-sections/a TF_LDFLAGS        +=      --no-warn-rwx-segment' Makefile
 		


### PR DESCRIPTION
I added conditions to detect on which architecture the compilation is being performed, and based on that, decide whether to use ARM's native compiler or the cross-compiler for the x86 architecture case. Therefore, the original functionality of the process for creating the microSD image was not affected.

On the other hand, I encountered problems when generating the imx-boot-sd.bin file, which I resolved based on the following information.

https://github.com/deamen/arm64v8/issues/2

https://lore.kernel.org/all/20230921215633.34828-2-brandon.maier@collins.com/

Finally, I have tested that this works on the Mac Mini by virtualizing a version of Ubuntu for ARM.
And I also tested the generated microSD on a Fika board, the operating system initialized and the Meticulous graphical interface was displayed